### PR TITLE
Fixed an issue with setting the NuGet package version when running via tag push

### DIFF
--- a/.github/workflows/build-nuget.yml
+++ b/.github/workflows/build-nuget.yml
@@ -80,12 +80,12 @@ jobs:
 
             - name: Package NuGet
               run: |
-                nuget pack OpenRA-OpenAL-CS.nuspec -OutputDirectory ./nuget -version ${{ github.event.inputs.nugetPackageVersion }}
+                nuget pack OpenRA-OpenAL-CS.nuspec -OutputDirectory ./nuget -version ${{ env.PACKAGE_VERSION }}
 
             - name: Upload NuGet package to Artifacts
               uses: actions/upload-artifact@v3
               with:
-                name: NuGet Package ${{ github.event.inputs.nugetPackageVersion }}
+                name: NuGet Package ${{ env.PACKAGE_VERSION }}
                 path: ./nuget
 
             - name: Tag a release


### PR DESCRIPTION
This would work when running the workflow manually, but not when running via a tag push. We already handle the difference above, so we just need to use the variable that we created.